### PR TITLE
Move to OpenStruct for internal resource representation

### DIFF
--- a/lib/wp_api_client/entities/base.rb
+++ b/lib/wp_api_client/entities/base.rb
@@ -1,4 +1,5 @@
 require 'open-uri'
+require 'ostruct'
 
 module WpApiClient
   module Entities
@@ -12,10 +13,10 @@ module WpApiClient
       end
 
       def initialize(resource)
-        unless resource.is_a? Hash
+        unless resource.is_a? Hash or resource.is_a? OpenStruct
           raise ArgumentError.new('Tried to initialize a WP-API resource with something other than a Hash')
         end
-        @resource = resource
+        @resource = OpenStruct.new(resource)
       end
 
       def links
@@ -30,6 +31,10 @@ module WpApiClient
         else
           relations
         end
+      end
+
+      def method_missing(method, *args)
+        @resource.send(method, *args)
       end
     end
   end

--- a/lib/wp_api_client/entities/meta.rb
+++ b/lib/wp_api_client/entities/meta.rb
@@ -7,13 +7,6 @@ module WpApiClient
         json["key"] and json["value"]
       end
 
-      def key
-        meta["key"]
-      end
-
-      def value
-        meta["value"]
-      end
     end
   end
 end

--- a/lib/wp_api_client/entities/post.rb
+++ b/lib/wp_api_client/entities/post.rb
@@ -11,10 +11,6 @@ module WpApiClient
         post["title"]["rendered"]
       end
 
-      def slug
-        post["slug"]
-      end
-
       def date
         Time.parse(post["date_gmt"]) if post["date_gmt"]
       end
@@ -25,10 +21,6 @@ module WpApiClient
 
       def excerpt
         post["excerpt"]["rendered"]
-      end
-
-      def id
-        post["id"]
       end
 
       def terms(taxonomy = nil)

--- a/lib/wp_api_client/entities/taxonomy.rb
+++ b/lib/wp_api_client/entities/taxonomy.rb
@@ -7,10 +7,6 @@ module WpApiClient
         !json.dig("hierarchical").nil?
       end
 
-      def name
-        taxonomy["name"]
-      end
-
       def terms
         relations("https://api.w.org/items")
       end

--- a/lib/wp_api_client/entities/term.rb
+++ b/lib/wp_api_client/entities/term.rb
@@ -15,18 +15,6 @@ module WpApiClient
         relations("http://api.w.org/v2/post_type", post_type)
       end
 
-      def name
-        term["name"]
-      end
-
-      def slug
-        term["slug"]
-      end
-
-      def id
-        term["id"]
-      end
-
     end
   end
 end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe WpApiClient::Entities::Post do
       expect(@post.slug).to eq 'hello-world'
     end
 
+    it "allows its internal resource to be queried directly" do
+      expect(@post.resource["slug"]).to eq 'hello-world'
+    end
+
   end
 
   describe "meta function" do


### PR DESCRIPTION
This simplifies the code and permits access to any field without needing to define custom getters.

Includes test for backwards compatibility.

eg
`post.my_field_added_on_rest_init`

instead of
`post.resource["my_field_added_on_rest_init"]`
