### PR TITLE
Relaxing ruby version dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /tmp/
 /config/oauth.json
 *.gem
+
+.idea

--- a/wp_api_client.gemspec
+++ b/wp_api_client.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.3'
-
   spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "faraday_middleware", "~> 0.10"
   spec.add_dependency "faraday-http-cache", "~> 1.2"


### PR DESCRIPTION
Remove ruby version dependency to allow more applications to use this plugin
