### PR TITLE
Fix oAuth tests on clean install

### DIFF
--- a/config/test-oauth-credentials.json
+++ b/config/test-oauth-credentials.json
@@ -1,0 +1,1 @@
+{"consumer_key":"DJyagPXmjMxO","consumer_secret":"h1gEQ4H0gd85uSR44XjWxgqwWaSOTjsJ6BBQjtkbq00TLYJF","token":"8w2Q6IJj63OB01FmNlu6WA5A","token_secret":"UIZKlUAQOBzTLuosshhQvirAZHtGfpBvDjdQCjAlkuME68C5"}

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe WpApiClient::Entities::Post do
 
     before :all do
       WpApiClient.reset!
-      oauth_credentials = JSON.parse(File.read('config/oauth.json'), symbolize_names: true)
+      oauth_credentials = get_test_oauth_credentials
 
       WpApiClient.configure do |api_client|
         api_client.oauth_credentials = oauth_credentials

--- a/spec/relationships_spec.rb
+++ b/spec/relationships_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe WpApiClient::Relationship do
     before :each do
       # we need oAuth for this
       WpApiClient.reset!
-      oauth_credentials = JSON.parse(File.read('config/oauth.json'), symbolize_names: true)
+      oauth_credentials = get_test_oauth_credentials
       WpApiClient.configure do |api_client|
         api_client.oauth_credentials = oauth_credentials
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,5 +122,10 @@ RSpec.configure do |config|
 =end
 end
 
+def get_test_oauth_credentials
+  # These credentials were used to construct the VCR cassettes so they're needed to run the tests
+  JSON.parse(File.read('config/test-oauth-credentials.json'), symbolize_names: true)
+end
+
 require 'wp_api_client'
 require 'json'

--- a/spec/wp_api_configuration_spec.rb
+++ b/spec/wp_api_configuration_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe WpApiClient::Configuration do
     end
 
     it "can set up OAuth credentials", vcr: {cassette_name: :oauth_test} do
-      oauth_credentials = JSON.parse(File.read('config/oauth.json'), symbolize_names: true)
+      oauth_credentials = get_test_oauth_credentials
 
       WpApiClient.configure do |api_client|
         api_client.oauth_credentials = oauth_credentials


### PR DESCRIPTION
Previously the tests would not run on a clean install because the `config/oauth.json` file was missing. This PR 
- retains the config folder in the project structure
- adds the OAuth credentials used in the creation of the VCR cassettes, so tests that touch oAuth work out of the box
